### PR TITLE
Fix generic types for ReactElement

### DIFF
--- a/react.d.ts
+++ b/react.d.ts
@@ -23,8 +23,8 @@ declare namespace React {
         ref?: Ref<T>;
     }
 
-    interface ReactElement<P> {
-        type: string | ComponentClass<P> | SFC<P>;
+    interface ReactElement<T extends Component<P, any>, P> {
+        type: string | ComponentClass<T> | SFC<T>;
         props: P;
         key?: Key;
     }


### PR DESCRIPTION
Hi,

I fixed a bug in the ReactElement definition.

The `props` should the props of the passed component, not the component itself.
