### PR TITLE
Revert "Fix generic types for ReactElement"

### DIFF
--- a/react.d.ts
+++ b/react.d.ts
@@ -23,8 +23,8 @@ declare namespace React {
         ref?: Ref<T>;
     }
 
-    interface ReactElement<T extends Component<P, any>, P> {
-        type: string | ComponentClass<T> | SFC<T>;
+    interface ReactElement<P> {
+        type: string | ComponentClass<P> | SFC<P>;
         props: P;
         key?: Key;
     }


### PR DESCRIPTION
Hello,

I'm sorry I forgot about this pull request, actually it's a mistake, the current typings work fine.

Reverts cantide5ga/typed-react#5